### PR TITLE
TRITON-2321 New apidocs URL

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "commands-show-output": false,
+    "line-length": false,
+    "single-h1": false
+}

--- a/README.md
+++ b/README.md
@@ -6,27 +6,26 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # sdc-docker
 
-This repository is part of the Joyent Triton project. See the [contribution
-guidelines](https://github.com/joyent/triton/blob/master/CONTRIBUTING.md)
+This repository is part of the Triton Data Center project. See the
+[contribution guidelines](https://github.com/TritonDataCenter/triton/blob/master/CONTRIBUTING.md)
 and general documentation at the main
-[Triton project](https://github.com/joyent/triton) page.
+[Triton project](https://github.com/TritonDataCenter/triton) page.
 
-SDC Docker is the Docker Engine for Triton, where the data center is exposed
+`sdc-docker` is the Docker Engine for Triton, where the data center is exposed
 as a single Docker host. The Docker remote API is served from a "docker" core
-SDC zone built from this repo.
-
+Triton zone built from this repo.
 
 # User Guide
 
-For users of the Triton service in Joyent's public cloud, or those using
-a private SDC Docker stand-up, but not administering it, please see the
+For users of the Triton service in a public cloud, or those using
+a private Triton Docker stand-up, but not administering it, please see the
 [User Guide](./docs/api/README.md).  The rest of this README is targeted at
 *development* of sdc-docker.
-
 
 # Docker Version
 
@@ -52,7 +51,6 @@ be sure to update the following:
 2. update the docker cli test client version in
    globe-theatre/bin/nightly-test-docker-integration-cli
 
-
 # Current State
 
 Many commands are currently at least partially implemented. See
@@ -61,11 +59,10 @@ diverges from Docker Inc's docker.  This software is under active development
 to provide parity to the newer Docker features that are relevant to SDC, as
 well as to integrate with other new Triton features .
 
-
 # Installation
 
 Note: Examples in this section are for
-[CoaL](https://github.com/joyent/sdc#cloud-on-a-laptop-coal), i.e. some
+[CoaL](https://github.com/TritonDataCenter/triton#cloud-on-a-laptop-coal), i.e. some
 setup will not be appropriate for a production DC.
 
 1. Installing sdc-docker and supporting services:
@@ -83,14 +80,14 @@ setup will not be appropriate for a production DC.
         #    sdcadm post-setup fabrics ...
         #    <reboot>
 
-For compute nodes added after the first-time setup, you will need to install
-the dockerlogger on them by executing:
+    For compute nodes added after the first-time setup, you will need to install
+    the dockerlogger on them by executing:
 
         sdcadm experimental update dockerlogger --servers ${CN1},${CN2},...
 
-SDC Docker uses (as of [DOCKER-312](https://smartos.org/bugview/DOCKER-312))
-TLS by default. That means you need to setup a user (or use the 'admin' user)
-and add an SSH key for access.
+    SDC Docker uses (as of [DOCKER-312](https://smartos.org/bugview/DOCKER-312))
+    TLS by default. That means you need to setup a user (or use the 'admin' user)
+    and add an SSH key for access.
 
 2. Create a test user (we'll use "jill"):
 
@@ -152,7 +149,7 @@ will need to re-run the ./tools/sdc-docker-setup.sh script.
 The public APIs to an SDC -- sdc-docker and cloudapi -- can be configured to
 be in invite-only mode where only explicitly allowed accounts are given
 authorized. This mode is configured via the `account_allowed_dcs`
-[SDC Application config var](https://github.com/joyent/sdc/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration).
+[SDC Application config var](https://github.com/TritonDataCenter/triton/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration).
 
     sdc-sapi /applications/$(sdc-sapi /applications?name=sdc | json -H 0.uuid) \
         -X PUT -d '{"metadata": {"account_allowed_dcs": true}}'
@@ -189,7 +186,6 @@ Limitation: Currently adding access can take a minute or two to take effect
 (caching) and removing access **requires the sdc-docker server to be
 restarted (DOCKER-233).**
 
-
 # Adding packages
 
 By default the size of the container (ram, disk, cpu shares) uses the package in
@@ -204,7 +200,6 @@ to use them:
     /opt/smartdc/bin/sapiadm update \
        $(/opt/smartdc/bin/sdc-sapi /services?name=docker | json -H 0.uuid) \
        metadata.PACKAGE_PREFIX="sample-"
-
 
 # Configurations
 
@@ -224,7 +219,6 @@ Here is an example of modifying the service configurations with SAPI,
     docker_svc=$(sdc-sapi /services?name=docker | json -Ha uuid)
     sdc-sapi /services/$docker_svc -X PUT -d '{ "metadata": { "USE_TLS": true } }'
 
-
 # Development hooks
 
 Before commiting be sure to:
@@ -236,7 +230,6 @@ A good way to do that is to install the stock pre-commit hook in your
 clone via:
 
     make git-hooks
-
 
 # Testing
 
@@ -265,7 +258,6 @@ run from your Mac dev tree, e.g.:
 
     ./test/runtest ./test/integration/cli-info.test.js
 
-
 By default all "cli" integration tests ("test/integration/cli-\*.test.js") are
 run against the latest Docker CLI version (see the
 `DOCKER_AVAILABLE_CLI_VERSIONS` variable in "test/runtest.common"). To run
@@ -276,8 +268,6 @@ against against other versions, or all supported versions, set the
     make test-integration-in-coal DOCKER_CLI_VERSIONS="1.11.1 1.10.3"
     DOCKER_CLI_VERSIONS=1.11.1 /zones/$(vmadm lookup -1 alias=docker0)/root/opt/smartdc/docker/test/runtests -f cli-info
     DOCKER_CLI_VERSIONS=latest /zones/$(vmadm lookup -1 alias=docker0)/root/opt/smartdc/docker/test/runtests -f cli-labels
-
-
 
 # Testing locally
 
@@ -319,7 +309,6 @@ docker binary and go (golang) installed, then do the following:
     # Run all tests - this will take forever... a specific test will be faster.
     go test -v
 
-
 # Development from your Mac
 
 1. Add a 'coal' entry to your '~/.ssh/config'. Not required, but we'll use this
@@ -335,7 +324,7 @@ docker binary and go (golang) installed, then do the following:
 
 2. Get a clone on your Mac:
 
-        git clone git@github.com:joyent/sdc-docker.git
+        git clone git@github.com:TritonDataCenter/sdc-docker.git
         cd sdc-docker
 
 3. Make changes in your local clone:
@@ -351,13 +340,11 @@ docker binary and go (golang) installed, then do the following:
    sdcnode version, or added binary node modules) and restart the docker
    SMF service.
 
-
 For testing I tend to have a shell open tailing the docker service's log file:
 
     ssh coal
     sdc-login docker
     tail -f `svcs -L docker` | bunyan
-
 
 # Coding style
 
@@ -376,7 +363,6 @@ for this repo:
 
         var ImageTag = require('.../models/image-tag');
         var Link = require('.../models/link');
-
 
 ## Naming
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -85,7 +85,7 @@ That should output something like the following:
 
 ```bash
 Setting up Docker client for SDC using:
-        CloudAPI:        https://us-east-1.api.mnx.io
+        CloudAPI:        https://us-central-1.api.mnx.io
         Account:         jill
         Key:             /Users/localuser/.ssh/sdc-docker.id_rsa
 
@@ -100,13 +100,13 @@ writing RSA key
 Wrote certificate files to /Users/localuser/.sdc/docker/jill
 
 Get Docker host endpoint from cloudapi.
-Docker service endpoint is: tcp://us-east-1.docker.mnx.io:2376
+Docker service endpoint is: tcp://us-central-1.docker.mnx.io:2376
 
 * * *
 Success. Set your environment as follows:
 
         export DOCKER_CERT_PATH=/Users/localuser/.sdc/docker/jill
-        export DOCKER_HOST=tcp://us-east-1.docker.mnx.io:2376
+        export DOCKER_HOST=tcp://us-central-1.docker.mnx.io:2376
         export DOCKER_CLIENT_TIMEOUT=300
         export COMPOSE_HTTP_TIMEOUT=300
         export DOCKER_TLS_VERIFY=1
@@ -130,7 +130,7 @@ Kernel Version: 3.12.0-1-amd64
 Operating System: SmartDataCenter
 CPUs: 0
 Total Memory: 0 B
-Name: us-east-1
+Name: us-central-1
 ID: 65698e31-2754-4e86-9d05-bfc881037812
 ```
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable code-block-style -->
+
 # Docker Remote API implementation for Triton
 
 This document explains how to set up your Docker client tools to manage the
@@ -15,7 +17,9 @@ have to interact with a single API endpoint for a given SDC implementation.
 
 Docker client applications, including the Docker CLI and Docker Compose, can connect to the SDC Docker remote API endpoint to launch and control Docker containers across an entire Triton data center.
 
-Connecting to the API requires an account on the Triton data center, SSH key, and the CloudAPI URL for that data center, as well as the Docker CLI or some other Docker client. Joyent provides a helper script to configure a Docker client, including the Docker CLI.
+Connecting to the API requires an account on the Triton data center, SSH key, and the CloudAPI URL for that data center, as well as the Docker CLI or some other Docker client. If you have your `triton` cli client configured, run:
+
+    eval "$(triton env -d)"
 
 ### Docker version
 
@@ -32,18 +36,15 @@ Please [install or upgrade](https://docs.docker.com/installation/#installation) 
 
 ### API endpoint
 
-Each data center is a single Docker API endpoint. [CloudAPI](https://apidocs.joyent.com/cloudapi/) is used as a helper to configure the client to connect to the Docker Remote API. Determining the correct CloudAPI URL depends on which data center you're connecting to.
+Each data center is a single Docker API endpoint. [CloudAPI](https://apidocs.tritondatacenter.com/cloudapi/) is used as a helper to configure the client to connect to the Docker Remote API. Determining the correct CloudAPI URL depends on which data center you're connecting to.
 
-Joyent operates a number of data centers around the world, each has its own CloudAPI endpoint. Please consult the Joyent Elastic Container Service documentation for the correct URL for that service.
-
-Private cloud implementations will offer different CloudAPI URLs, please consult the private cloud operator for the correct URL.
+See your cloud provider's documentation or operator(s) for the CloudAPI endpoint.
 
 ### User accounts, authentication, and security
 
 User accounts in Triton require one or more SSH keys. The keys are used to identify and secure SSH access to containers and other resources in Triton.
 
 SDC Docker uses Docker's TLS authentication scheme both to identify the requesting user and secure the API endpoint. The SDC Docker helper script will generates a TLS certificate using your SSH key and write it to a directory in your user account.
-
 
 ### The helper script
 
@@ -52,7 +53,7 @@ The 'sdc-docker-setup.sh' script will help pull everything together and configur
 Download the script:
 
 ```bash
-curl -O https://raw.githubusercontent.com/joyent/sdc-docker/master/tools/sdc-docker-setup.sh
+curl -O https://raw.githubusercontent.com/TritonDataCenter/sdc-docker/master/tools/sdc-docker-setup.sh
 ```
 
 Now execute the script, substituting the correct values:
@@ -61,34 +62,32 @@ Now execute the script, substituting the correct values:
 bash sdc-docker-setup.sh <CLOUDAPI_URL> <ACCOUNT_USERNAME> ~/.ssh/<PRIVATE_KEY_FILE>
 ```
 
-Possible values for `<CLOUDAPI_URL>` include any of Joyent's data centers
+Possible values for `<CLOUDAPI_URL>` include MNX's data centers
 which are hosting Triton or another CloudAPI, e.g. one running in a [Cloud on a
-Laptop (CoaL)](https://github.com/joyent/sdc#cloud-on-a-laptop-coal) development
+Laptop (CoaL)](https://github.com/TritonDataCenter/triton#cloud-on-a-laptop-coal) development
 VMware VM.
 
 | CLOUDAPI_URL | Description |
 | ------------ | ----------- |
-| https://us-east-1.api.joyent.com | Joyent's us-east-1 data center. |
-| https://us-sw-1.api.joyent.com | Joyent's us-sw-1 data center. |
-| https://eu-ams-1.api.joyent.com | Joyent's eu-ams-1 (Amsterdam) data center. |
+| `https://us-central-1.api.mnx.io` | MNX us-central-1 data center. |
 | coal | Special name to indicate the CloudAPI in a development CoaL VMware VM |
 
-
-For example, if you created an account on [Joyent's hosted Triton
-service](https://www.joyent.com/triton), with the username "jill", SSH key file
-"~/.ssh/sdc-docker.id_rsa", and connecting to the US East-1 data center:
+For example, if you created an account on
+[MNX's hosted Triton service](https://my.mnx.io), with the
+username "jill", SSH key file `~/.ssh/sdc-docker.id_rsa`, and connecting to the
+US-Central-1 data center:
 
 ```bash
-bash sdc-docker-setup.sh https://us-east-1.api.joyent.com jill ~/.ssh/sdc-docker.id_rsa
+bash sdc-docker-setup.sh https://us-central-1.api.mnx.io jill ~/.ssh/sdc-docker.id_rsa
 ```
 
 That should output something like the following:
 
 ```bash
 Setting up Docker client for SDC using:
-	CloudAPI:        https://us-east-1.api.joyent.com
-	Account:         jill
-	Key:             /Users/localuser/.ssh/sdc-docker.id_rsa
+        CloudAPI:        https://us-east-1.api.mnx.io
+        Account:         jill
+        Key:             /Users/localuser/.ssh/sdc-docker.id_rsa
 
 If you have a pass phrase on your key, the openssl command will
 prompt you for your pass phrase now and again later.
@@ -101,16 +100,16 @@ writing RSA key
 Wrote certificate files to /Users/localuser/.sdc/docker/jill
 
 Get Docker host endpoint from cloudapi.
-Docker service endpoint is: tcp://us-east-1.docker.joyent.com:2376
+Docker service endpoint is: tcp://us-east-1.docker.mnx.io:2376
 
 * * *
 Success. Set your environment as follows:
 
-	export DOCKER_CERT_PATH=/Users/localuser/.sdc/docker/jill
-	export DOCKER_HOST=tcp://us-east-1.docker.joyent.com:2376
-	export DOCKER_CLIENT_TIMEOUT=300
+        export DOCKER_CERT_PATH=/Users/localuser/.sdc/docker/jill
+        export DOCKER_HOST=tcp://us-east-1.docker.mnx.io:2376
+        export DOCKER_CLIENT_TIMEOUT=300
         export COMPOSE_HTTP_TIMEOUT=300
-	export DOCKER_TLS_VERIFY=1
+        export DOCKER_TLS_VERIFY=1
 ```
 
 Then you should be able to run 'docker info' and see your account
@@ -134,6 +133,7 @@ Total Memory: 0 B
 Name: us-east-1
 ID: 65698e31-2754-4e86-9d05-bfc881037812
 ```
+
 ## Troubleshooting API connection problems
 
 See our [guide to common API connection problems](./troubleshooting.md).

--- a/docs/api/commands/build.md
+++ b/docs/api/commands/build.md
@@ -274,7 +274,6 @@ like `ENV` values do.
 For detailed information on using `ARG` and `ENV` instructions, see the
 [Dockerfile reference](../builder.md).
 
-
 ## Divergence
 
 Triton's secure, multi-tenant, container-native environment imposes some
@@ -284,7 +283,7 @@ manage CPU allocation, or networking, are more effective because of features
 unique to Triton.
 
 * `--cgroup-parent` is ignored. See [security](../features/security.md).
-* `--cpu-shares` and `-c` are ignored, though CPU resources can be specified in conjunction with RAM. See [resource allocation](../features/resources.md). Joyent is working with the Docker community to improve how CPU resources are specified in the API.
+* `--cpu-shares` and `-c` are ignored, though CPU resources can be specified in conjunction with RAM. See [resource allocation](../features/resources.md).
 * `--cap-add` and `--cap-drop` (Linux capabilities) are ignored. See [security](../features/security.md).
 * `--cpuset-cpus` and `--cpuset-mems` (controls which CPUs and memory nodes to run on) are ignored. See [resource allocation](../features/resources.md).
 * `--cpu-period` and `--cpu-quota` (limit the CPU CFS settings) are ignored. See [resource allocation](../features/resources.md).
@@ -294,7 +293,7 @@ unique to Triton.
 * `--shm-size` is ignored.
 * `--ulimit` (ulimit options) is unsupported.
 
-### Docker build step divergence:
+### Docker build step divergence
 
 * `ADD` with remote URL is unimplemented.
 * the build container is reused for each build step (instead of creating a new
@@ -302,6 +301,6 @@ unique to Triton.
 
 ## Related
 
-- [`docker commit`](../commands/commit.md)
-- [`docker images`](../commands/images.md)
-- [`docker push`](../commands/push.md)
+* [`docker commit`](../commands/commit.md)
+* [`docker images`](../commands/images.md)
+* [`docker push`](../commands/push.md)

--- a/docs/api/commands/commit.md
+++ b/docs/api/commands/commit.md
@@ -74,7 +74,7 @@ created.  Supported `Dockerfile` instructions:
 ## Divergence
 
 There is no known divergence between the Triton SDC Docker and Docker Inc.
-implementations of this method. Please contact Joyent support or file a ticket
+implementations of this method. Please file a ticket
 if you discover any.
 
 ## Related

--- a/docs/api/commands/create.md
+++ b/docs/api/commands/create.md
@@ -92,7 +92,6 @@ Creates a new container.
       --volumes-from=[]                Mount volumes from the specified container(s)
       -w, --workdir=""                 Working directory inside the container
 
-
 The `docker create` command creates a writeable container layer over
 the specified image and prepares it for running the specified command.
 The container ID is then printed to `STDOUT`.
@@ -197,14 +196,14 @@ Windows-based images and the associated parameters are not supported on Triton.
   NFS volume feature.
 
 Docker Swarm's affinity filters  (also called "locality hints" in Triton, see
-the [cloudapi CreateMachine notes](https://apidocs.joyent.com/cloudapi/
-#CreateMachine)) for controlling on which server a container is provisioned are 
-supported. See the [placement feature documentation](../features/placement.md) 
+the [cloudapi CreateMachine notes](https://apidocs.tritondatacenter.com/cloudapi/#CreateMachine))
+for controlling on which server a container is provisioned are
+supported. See the [placement feature documentation](../features/placement.md)
 for details.
 
-Please contact Joyent support or file a ticket if you discover any additional divergence.
+Please file a ticket if you discover any additional divergence.
 
 ## Related
 
-- [`docker ps`](../commands/ps.md)
-- [`sdc-createmachine`](https://apidocs.joyent.com/cloudapi/#CreateMachine) and `POST /my/machines` in CloudAPI
+* [`docker ps`](../commands/ps.md)
+* [`sdc-createmachine`](https://apidocs.tritondatacenter.com/cloudapi/#CreateMachine) and `POST /my/machines` in CloudAPI

--- a/docs/api/commands/events.md
+++ b/docs/api/commands/events.md
@@ -6,4 +6,4 @@ This command is currently unimplemented. Follow [DOCKER-78](http://smartos.org/b
 
 ## Related
 
-- [`sdc-getmachineaudit`](https://apidocs.joyent.com/cloudapi/#MachineAudit) and `GET /my/machines/:id/audit` in CloudAPI
+* [`sdc-getmachineaudit`](https://apidocs.tritondatacenter.com/cloudapi/#MachineAudit) and `GET /my/machines/:id/audit` in CloudAPI

--- a/docs/api/commands/history.md
+++ b/docs/api/commands/history.md
@@ -31,7 +31,7 @@ To see how the `docker:apache` image was added to a container's base image:
 ## Divergence
 
 There is no known divergence between the Triton SDC Docker and Docker Inc.
-implementations of this method. Please contact Joyent support or file a ticket
+implementations of this method. Please file a ticket
 if you discover any.
 
 ## Related

--- a/docs/api/commands/images.md
+++ b/docs/api/commands/images.md
@@ -120,7 +120,7 @@ images.
 ## Divergence
 
 There is no known divergence between the Triton SDC Docker and Docker Inc.
-implementations of this method. Please contact Joyent support or file a ticket
+implementations of this method. Please file a ticket
 if you discover any.
 
 ## Related

--- a/docs/api/commands/info.md
+++ b/docs/api/commands/info.md
@@ -51,7 +51,7 @@ ensure we know how your setup is configured.
 * SDCAccount will show you the name of the SDC account you're authenticated as
 * Name will show you the datacenter name
 
-Please contact Joyent support or file a ticket if you discover any additional divergence.
+Please file a ticket if you discover any additional divergence.
 
 ## Related
 

--- a/docs/api/commands/inspect.md
+++ b/docs/api/commands/inspect.md
@@ -86,9 +86,9 @@ Read more about container [security on Triton](features/security.md) and see [no
 
 The `-s` and `--size` options are currently unsupported.
 
-Please contact Joyent support or file a ticket if you discover any additional divergence.
+Please file a ticket if you discover any additional divergence.
 
 ## Related
 
 - [`docker port`](../commands/port.md) as in `docker port $(docker ps -l -q)`
-- [`sdc-getmachine`](https://apidocs.joyent.com/cloudapi/#GetMachine) and `GET /my/machines/:id` in CloudAPI
+- [`sdc-getmachine`](https://apidocs.tritondatacenter.com/cloudapi/#GetMachine) and `GET /my/machines/:id` in CloudAPI

--- a/docs/api/commands/kill.md
+++ b/docs/api/commands/kill.md
@@ -47,9 +47,9 @@ SDC Docker only supports a subset of signals for `docker kill`. These currently 
 - `SIGXCPU`
 - `SIGXFSZ`
 
-Please contact Joyent support or file a ticket if you discover any additional divergence.
+Please file a ticket if you discover any additional divergence.
 
 ## Related
 
 - [`docker stop`](../commands/stop.md) as in `docker stop $(docker ps -a -q)`
-- [`sdc-stopmachine`](https://apidocs.joyent.com/cloudapi/#StopMachine) and `POST /my/machines/:id?action=stop` in CloudAPI
+- [`sdc-stopmachine`](https://apidocs.tritondatacenter.com/cloudapi/#StopMachine) and `POST /my/machines/:id?action=stop` in CloudAPI

--- a/docs/api/commands/login.md
+++ b/docs/api/commands/login.md
@@ -24,7 +24,7 @@ See also [Private registries](../features/repos.md) for more information.
 ## Divergence
 
 There is no known divergence between the Triton SDC Docker and Docker Inc.
-implementations of this method. Please contact Joyent support or file a ticket
+implementations of this method. Please file a ticket
 if you discover any.
 
 ## Related

--- a/docs/api/commands/logout.md
+++ b/docs/api/commands/logout.md
@@ -17,7 +17,7 @@ the server name.
 ## Divergence
 
 There is no known divergence between the Triton SDC Docker and Docker Inc.
-implementations of this method. Please contact Joyent support or file a ticket
+implementations of this method. Please file a ticket
 if you discover any.
 
 ## Related

--- a/docs/api/commands/port.md
+++ b/docs/api/commands/port.md
@@ -2,8 +2,8 @@
 
     Usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]
 
-    List port mappings for the CONTAINER, or lookup the public-facing port that is
-	NAT-ed to the PRIVATE_PORT
+    List port mappings for the CONTAINER, or lookup the public-facing port that
+    is NAT-ed to the PRIVATE_PORT
 
 You can find out all the ports mapped by not specifying a `PRIVATE_PORT`, or
 just a specific mapping:
@@ -23,8 +23,8 @@ just a specific mapping:
 
 ## Divergence
 
-There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please file a ticket if you discover any.
 
 ## Related
 
-- [`sdc-listmachinefirewallrules`](https://apidocs.joyent.com/cloudapi/#ListMachineFirewallRules) and `GET /my/machines/:id/fwrules` in CloudAPI
+- [`sdc-listmachinefirewallrules`](https://apidocs.tritondatacenter.com/cloudapi/#ListMachineFirewallRules) and `GET /my/machines/:id/fwrules` in CloudAPI

--- a/docs/api/commands/ps.md
+++ b/docs/api/commands/ps.md
@@ -29,10 +29,11 @@ is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar"
 --filter "bif=baz"`)
 
 Current filters:
- * id (container's id)
- * name (container's name)
- * exited (int - the code of exited containers. Only useful with '--all')
- * status (restarting|running|paused|exited)
+
+* id (container's id)
+* name (container's name)
+* exited (int - the code of exited containers. Only useful with '--all')
+* status (restarting|running|paused|exited)
 
 ## Examples
 
@@ -64,14 +65,14 @@ This shows all the containers that have exited with status of '0'
 This command does not support the *Size* field. All sizes will be returned as 0.
 See [DOCKER-285](http://smartos.org/bugview/DOCKER-285) to follow this issue.
 
-Please contact Joyent support or file a ticket if you discover any additional
+Please file a ticket if you discover any additional
 divergence.
 
 ## Related
 
-- [`docker inspect`](../commands/inspect.md) as in
+* [`docker inspect`](../commands/inspect.md) as in
   `docker inspect $(docker ps -l -q)`
-- [`docker rm`](../commands/rm.md) as in `docker rm $(docker ps -a -q)`
-- [`sdc-listmachines`](https://apidocs.joyent.com/cloudapi/#ListMachines)
+* [`docker rm`](../commands/rm.md) as in `docker rm $(docker ps -a -q)`
+* [`sdc-listmachines`](https://apidocs.tritondatacenter.com/cloudapi/#ListMachines)
   and `GET /my/machines` in CloudAPI
-- [`vmadm list`](https://smartos.org/man/1m/vmadm) in SDC private API
+* [`vmadm list`](https://smartos.org/man/1m/vmadm) in SDC private API

--- a/docs/api/commands/rename.md
+++ b/docs/api/commands/rename.md
@@ -8,8 +8,8 @@ The `docker rename` command allows the container to be renamed to a different na
 
 ## Divergence
 
-There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please file a ticket if you discover any.
 
 ## Related
 
-- [`sdc-renamemachine`](https://apidocs.joyent.com/cloudapi/#RenameMachine) and `POST /my/machines/:id?action=rename` in CloudAPI
+* [`sdc-renamemachine`](https://apidocs.tritondatacenter.com/cloudapi/#RenameMachine) and `POST /my/machines/:id?action=rename` in CloudAPI

--- a/docs/api/commands/restart.md
+++ b/docs/api/commands/restart.md
@@ -8,8 +8,8 @@
 
 ## Divergence
 
-There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please file a ticket if you discover any.
 
 ## Related
 
-- [`sdc-rebootmachine`](https://apidocs.joyent.com/cloudapi/#RebootMachine) and `POST /my/machines/:id?action=reboot` in CloudAPI
+* [`sdc-rebootmachine`](https://apidocs.tritondatacenter.com/cloudapi/#RebootMachine) and `POST /my/machines/:id?action=reboot` in CloudAPI

--- a/docs/api/commands/rm.md
+++ b/docs/api/commands/rm.md
@@ -42,8 +42,8 @@ The SDC Docker implementation does not support the following arguments:
 * `--link` does nothing
 * `--volumes` does nothing
 
-Please contact Joyent support or file a ticket if you discover any additional divergence.
+Please file a ticket if you discover any additional divergence.
 
 ## Related
 
-- [`sdc-deletemachine`](https://apidocs.joyent.com/cloudapi/#DeleteMachine) and `DELETE /my/machines/:id` in CloudAPI
+* [`sdc-deletemachine`](https://apidocs.tritondatacenter.com/cloudapi/#DeleteMachine) and `DELETE /my/machines/:id` in CloudAPI

--- a/docs/api/commands/rmi.md
+++ b/docs/api/commands/rmi.md
@@ -70,8 +70,8 @@ SDC Docker does not support the following arguments for this command:
 
 * `--no-prune`
 
-Please contact Joyent support or file a ticket if you discover any other variance.
+Please file a ticket if you discover any other variance.
 
 ## Related
 
-- [`docker images`](../commands/images.md)
+* [`docker images`](../commands/images.md)

--- a/docs/api/commands/run.md
+++ b/docs/api/commands/run.md
@@ -332,23 +332,20 @@ By default, the container will be able to `read`, `write` and `mknod` these devi
 This can be overridden using a third `:rwm` set of options to each `--device`
 flag:
 
+    $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
-```
-	$ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+    Command (m for help): q
+    $ docker run --device=/dev/sda:/dev/xvdc:r --rm -it ubuntu fdisk  /dev/xvdc
+    You will not be able to write the partition table.
 
-	Command (m for help): q
-	$ docker run --device=/dev/sda:/dev/xvdc:r --rm -it ubuntu fdisk  /dev/xvdc
-	You will not be able to write the partition table.
+    Command (m for help): q
 
-	Command (m for help): q
+    $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
-	$ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+    Command (m for help): q
 
-	Command (m for help): q
-
-	$ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
-	fdisk: unable to open /dev/xvdc: Operation not permitted
-```
+    $ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
+    fdisk: unable to open /dev/xvdc: Operation not permitted
 
 > **Note:**
 > `--device` cannot be safely used with ephemeral devices. Block devices that
@@ -391,6 +388,8 @@ Use Docker's `--restart` to specify a container's *restart policy*. A restart
 policy controls whether the Docker daemon restarts a container after exit.
 Docker supports the following restart policies:
 
+<!-- markdownlint-disable no-inline-html -->
+
 <table>
   <thead>
     <tr>
@@ -429,6 +428,8 @@ Docker supports the following restart policies:
   </tbody>
 </table>
 
+<!-- markdownlint-enable no-inline-html -->
+
     $ docker run --restart=always redis
 
 This will run the `redis` container with a restart policy of **always**
@@ -443,7 +444,6 @@ of the Docker run reference page.
 You can add other hosts into a container's `/etc/hosts` file by using one or more
 `--add-host` flags. This example adds a static address for a host named `docker`:
 
-```
     $ docker run --add-host=docker:10.180.0.1 --rm -it debian
     $$ ping docker
     PING docker (10.180.0.1): 48 data bytes
@@ -452,7 +452,6 @@ You can add other hosts into a container's `/etc/hosts` file by using one or mor
     ^C--- docker ping statistics ---
     2 packets transmitted, 2 packets received, 0% packet loss
     round-trip min/avg/max/stddev = 7.600/19.152/30.705/11.553 ms
-```
 
 Sometimes you need to connect to the Docker host from within your
 container.  To enable this, pass the Docker host's IP address to
@@ -477,17 +476,17 @@ available in the default container, you can set these using the `--ulimit` flag.
 `--ulimit` is specified with a soft and hard limit as such:
 `<type>=<soft limit>[:<hard limit>]`, for example:
 
-```
     $ docker run --ulimit nofile=1024:1024 --rm debian ulimit -n
     1024
-```
 
 >**Note:**
+>
 > If you do not provide a `hard limit`, the `soft limit` will be used for both
 values. If no `ulimits` are set, they will be inherited from the default `ulimits`
 set on the daemon.
 > `as` option is disabled now. In other words, the following script is not supported:
->   `$ docker run -it --ulimit as=1024 fedora /bin/bash`
+>
+>     $ docker run -it --ulimit as=1024 fedora /bin/bash
 
 ## Divergence
 
@@ -545,15 +544,14 @@ Windows-based images and the associated parameters are not supported on Triton.
   NFS volume feature.
 
 Docker Swarm's affinity filters  (also called "locality hints" in Triton, see
-the [cloudapi CreateMachine notes](https://apidocs.joyent.com/cloudapi/
-#CreateMachine)) for controlling on which server a container is provisioned are 
-supported. See the [placement feature documentation](../features/placement.md) 
+the [cloudapi CreateMachine notes](https://apidocs.tritondatacenter.com/cloudapi/#CreateMachine))
+for controlling on which server a container is provisioned are
+supported. See the [placement feature documentation](../features/placement.md)
 for details.
-
 
 ## Related
 
-- [`docker ps`](../commands/ps.md)
-- [`networks`](../features/networks.md) for external and overlay networking
-- [`CPU, memory and disk resource allocation`](../features/resources.md)
-- [`sdc-createmachine`](https://apidocs.joyent.com/cloudapi/#CreateMachine) and `POST /my/machines` in CloudAPI
+* [`docker ps`](../commands/ps.md)
+* [`networks`](../features/networks.md) for external and overlay networking
+* [`CPU, memory and disk resource allocation`](../features/resources.md)
+* [`sdc-createmachine`](https://apidocs.tritondatacenter.com/cloudapi/#CreateMachine) and `POST /my/machines` in CloudAPI

--- a/docs/api/commands/run.md
+++ b/docs/api/commands/run.md
@@ -318,10 +318,10 @@ logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
-   $ docker run --device=/dev/sdc:/dev/xvdc --device=/dev/sdd --device=/dev/zero:/dev/nulo -i -t ubuntu ls -l /dev/{xvdc,sdd,nulo}
-   brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
-   brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
-   crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
+    $ docker run --device=/dev/sdc:/dev/xvdc --device=/dev/sdd --device=/dev/zero:/dev/nulo -i -t ubuntu ls -l /dev/{xvdc,sdd,nulo}
+    brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
+    brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
+    crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
 
 It is often necessary to directly expose devices to a container. The `--device`
 option enables that.  For example, a specific block storage device or loop
@@ -340,7 +340,7 @@ flag:
 
     Command (m for help): q
 
-    $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+    $ docker run --device=/dev/sda:/dev/xvdc:rw --rm -it ubuntu fdisk  /dev/xvdc
 
     Command (m for help): q
 

--- a/docs/api/commands/start.md
+++ b/docs/api/commands/start.md
@@ -14,4 +14,4 @@
 
 ## Related
 
-- [`sdc-startmachine`](https://apidocs.joyent.com/cloudapi/#StartMachine) and `POST /my/machines/:id?action=start` in CloudAPI
+* [`sdc-startmachine`](https://apidocs.tritondatacenter.com/cloudapi/#StartMachine) and `POST /my/machines/:id?action=start` in CloudAPI

--- a/docs/api/commands/stats.md
+++ b/docs/api/commands/stats.md
@@ -15,17 +15,16 @@ Example:
     redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
     redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
 
-
 ## Divergence
 
 Whilst the major stats (CPU, network, memory) are covered, not all of the
 underlying docker stats (cgroups) data points are available, see:
 
-- [docker-stats.js](https://github.com/joyent/sdc-cn-agent/blob/master/bin/docker-stats.js)
+- [docker-stats.js](https://github.com/TritonDataCenter/sdc/sdc-cn-agent/blob/master/bin/docker-stats.js)
 
 Also the `-a` and `--all` options are not supported.
 
 ## Related
 
-- [Container Monitor 'cmon'](https://github.com/joyent/triton-cmon/tree/master/docs)
-- [Container Monitor with Prometheus](https://docs.joyent.com/public-cloud/api-access/prometheus)
+- [Container Monitor 'cmon'](https://github.com/TritonDataCenter/sdc/triton-cmon/tree/master/docs)
+- [Container Monitor with Prometheus](https://docs.tritondatacenter.com/public-cloud/api-access/prometheus)

--- a/docs/api/commands/stop.md
+++ b/docs/api/commands/stop.md
@@ -3,7 +3,7 @@
     Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 
     Stop a running container by sending SIGTERM and then SIGKILL after a
-	grace period
+    grace period
 
       -t, --time=10      Seconds to wait for stop before killing it
 
@@ -12,8 +12,8 @@ grace period, `SIGKILL`.
 
 ## Divergence
 
-There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please file a ticket if you discover any.
 
 ## Related
 
-- [`sdc-stopmachine`](https://apidocs.joyent.com/cloudapi/#StopMachine) and `POST /my/machines/:id?action=stop` in CloudAPI
+* [`sdc-stopmachine`](https://apidocs.tritondatacenter.com/cloudapi/#StopMachine) and `POST /my/machines/:id?action=stop` in CloudAPI

--- a/docs/api/commands/top.md
+++ b/docs/api/commands/top.md
@@ -6,11 +6,11 @@
 
 ## Divergence
 
-- With SDC Docker, `docker top` does not currently support the `ps_args` option and always returns results in the same format. This format is hardcoded pending upstream integration of some solution to the issues described in https://github.com/docker/docker/pull/9232.
+* With SDC Docker, `docker top` does not currently support the `ps_args` option and always returns results in the same format. This format is hardcoded pending upstream integration of some solution to the issues described in <https://github.com/docker/docker/pull/9232>.
 
-Please contact Joyent support or file a ticket if you discover any other divergence.
+Please file a ticket if you discover any other divergence.
 
 ## Related
 
-- [`Analytics`](https://apidocs.joyent.com/cloudapi/#analytics) in CloudAPI
-- [`prstats`](https://smartos.org/man/1M/prstat) SmartOS utility
+* [`Analytics`](https://apidocs.tritondatacenter.com/cloudapi/#analytics) in CloudAPI
+* [`prstats`](https://smartos.org/man/1M/prstat) SmartOS utility

--- a/docs/api/commands/version.md
+++ b/docs/api/commands/version.md
@@ -33,7 +33,7 @@ Known differences:
 - Server version reflects the sdc-docker version, which will vary from the Docker Inc. daemon version.
 - Go version on the server is actually a node.js version.
 
-Please contact Joyent support or file a ticket if you discover any additional differences.
+Please file a ticket if you discover any additional differences.
 
 ## Related
 

--- a/docs/api/commands/wait.md
+++ b/docs/api/commands/wait.md
@@ -6,7 +6,7 @@
 
 ## Divergence
 
-There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please file a ticket if you discover any.
 
 See also [notes about exit statuses](../divergence.md).
 

--- a/docs/api/divergence.md
+++ b/docs/api/divergence.md
@@ -1,13 +1,13 @@
 # Divergence
 
-Joyent's implementation of the Docker Remote API has some added features as well as omissions where the API conflicted with the needs of deploying containers across Triton data centers.
+Triton's implementation of the Docker Remote API has some added features as well as omissions where the API conflicted with the needs of deploying containers across Triton data centers.
 
 ## Features
 
-- [CPU and memory resource allocation](features/resources.md)
-- [Overlay networks](features/networks.md)
-- [Volumes](features/volumes.md)
-- [Private registries](features/repos.md)
+* [CPU and memory resource allocation](features/resources.md)
+* [Overlay networks](features/networks.md)
+* [Volumes](features/volumes.md)
+* [Private registries](features/repos.md)
 
 ## Container behavior and contents
 
@@ -47,22 +47,15 @@ emulation.
 #### objfs on /system/object
 
 This is the SmartOS kernel object filesystem. The contents of the filesystem
-are dynamic and reflect the current state of the system. See:
-
-http://illumos.org/man/7fs/objfs
-
-for more information.
+are dynamic and reflect the current state of the system. See
+<http://illumos.org/man/7fs/objfs> for more information.
 
 #### ctfs on /system/contract
 
 This is the SmartOS contract file system which is the interface to the SmartOS
 contract subsystem.
 
-See:
-
-http://illumos.org/man/4/contract
-
-for more information.
+See <http://illumos.org/man/4/contract> for more information.
 
 ### Exit Statuses
 
@@ -79,7 +72,7 @@ are working on, and intend to keep improving over time.
 
 ## Docker Remote API methods and Docker CLI commands
 
-In most cases Joyent has taken great efforts to be [bug for bug compatible](http://en.wikipedia.org/wiki/Bug_compatibility) with Docker Inc's API implementation (see [restart policies](./features/restart.md)). Please see documentation for [specific methods](./commands/) for any known divergence and file bugs as needed.
+In most cases Triton developers have taken great efforts to be [bug for bug compatible](http://en.wikipedia.org/wiki/Bug_compatibility) with Docker Inc's API implementation (see [restart policies](./features/restart.md)). Please see documentation for [specific methods](./commands/) for any known divergence and file bugs as needed.
 
 SDC Docker implements all the API methods necessary to build and deploy Docker
 containers in the cloud, though there are some missing docker API methods.
@@ -90,17 +83,18 @@ expect it to get shorter by the day:
 `docker network`, `docker node`, `docker pause`, `docker save`,
 `docker service`, `docker swarm`, `docker unpause`, `docker update`
 
-### Roadmap:
-- `docker network` is on our near-term roadmap, follow
+### Roadmap
+
+* `docker network` is on our near-term roadmap, follow
 [DOCKER-722](http://smartos.org/bugview/DOCKER-722), [DOCKER-723](http://smartos.org/bugview/DOCKER-723),
 [DOCKER-724](http://smartos.org/bugview/DOCKER-724), [DOCKER-725](http://smartos.org/bugview/DOCKER-725)
   for updates.
-- `docker events` will not be implemented in the near future. This causes a
+* `docker events` will not be implemented in the near future. This causes a
   trivial error when attempting to watch logs with `docker-compose`. Users who
   intend to use `docker events` for container orchestration purposes should
   look at [ContainerPilot](https://www.joyent.com/containerpilot)’s automatic
   service registration, health checking, and configuration.
-- There is no plan to implement `docker node` and `docker swarm` as Triton is
+* There is no plan to implement `docker node` and `docker swarm` as Triton is
   already working as a horizontally scalable cluster. There is no need for a
   set of compute node orchestration commands.
 
@@ -144,7 +138,6 @@ users access to all their logs.
 For the operator of SDC Docker these additional logs will require some cleanup
 process for long-lived containers when Manta support is not available.
 
-
 ## Container Labels
 
 Triton uses (and reserves) a number of custom container labels, to provide
@@ -162,14 +155,13 @@ names are currently defined:
 * `triton.network.public` (string): Set on a container, used to specify the
   external network name the instance will use.
 
-The `com.joyent.*` namespace is reserved for Joyent/Triton specific use cases,
+The `com.joyent.*` namespace is reserved for Triton specific use cases,
 these label names are currently defined:
 
 * `com.joyent.package` (string): Set on a container, used to choose a specific
   package for the container. The value can be a package name like
   `g4-standard-1G`, a UUID, or the first 8 characters of a UUID
   (short-UUID).
-
 
 ## Other Differences
 

--- a/docs/api/features/networks.md
+++ b/docs/api/features/networks.md
@@ -16,10 +16,8 @@ network, it affects only the newly provisioned containers. You may specify
 a different fabric network during provisioning by passing the `--network`
 argument in `docker run` and `docker create`, e.g.
 
-```
-   docker run --network=dev-net-123 busybox
-   docker run --network=d8f607e4 -P -d nginx
-```
+    docker run --network=dev-net-123 busybox
+    docker run --network=d8f607e4 -P -d nginx
 
 The work to support `docker network` commands is in progress. Follow
 [DOCKER-722](http://smartos.org/bugview/DOCKER-722),
@@ -30,13 +28,13 @@ The work to support `docker network` commands is in progress. Follow
 All docker containers owned by a user have firewalls enabled by default, and
 their default policy is to block all incoming traffic and allow all outbound
 traffic. All docker VMs have a
-[Cloud Firewall](https://www.joyent.com/developers/firewall/) rule
-automatically created that allows them to communicate with each other on all
-ports.
+[Cloud Firewall](https://docs.tritondatacenter.com/public-cloud/network/firewall)
+rule automatically created that allows them to communicate with each other on
+all ports.
 
 If you specify the -p or -P options to `docker run` or `docker create`, the
 container will receive an external IP address that is reachable over the public
-internet, and [Cloud Firewall](https://www.joyent.com/developers/firewall/)
+internet, and [Cloud Firewall](https://docs.tritondatacenter.com/public-cloud/network/firewall)
 rules are automatically created that allow incoming traffic to the appropriate
 ports from any IP address. For `-P`, this means all ports that the VM's image
 exposes. For `-p`, this means all ports specified as arguments. Port remapping
@@ -49,17 +47,14 @@ a nic on the 'external' network by default.
 The external network used by a container can be changed by setting the
 `triton.network.public` label to the name of the desired external network, e.g.
 
-```
-docker run --label triton.network.public=external2
-```
+    docker run --label triton.network.public=external2
 
 Note that this this only overrides the default public network selection. This
 means that when fabric networks are enabled you will still need to specify one
 of `-p` or `-P` to get the public NIC.
 
-
 ## Related
 
-- [`sdc-fabric vlan`](https://apidocs.joyent.com/cloudapi/#CreateFabricVLAN) and `POST /my/fabrics/default/vlans` in CloudAPI
-- [`sdc-fabric network`](https://apidocs.joyent.com/cloudapi/#CreateFabricNetwork) and `POST /my/fabrics/default/vlans/:id/networks` in CloudAPI
-- [`sdc-fabric network set-default`](https://apidocs.joyent.com/cloudapi/#UpdateConfig) and `PUT /my/config` in CloudAPI
+* [`sdc-fabric vlan`](https://apidocs.tritondatacenter.com/cloudapi/#CreateFabricVLAN) and `POST /my/fabrics/default/vlans` in CloudAPI
+* [`sdc-fabric network`](https://apidocs.tritondatacenter.com/cloudapi/#CreateFabricNetwork) and `POST /my/fabrics/default/vlans/:id/networks` in CloudAPI
+* [`sdc-fabric network set-default`](https://apidocs.tritondatacenter.com/cloudapi/#UpdateConfig) and `PUT /my/config` in CloudAPI

--- a/docs/api/features/placement.md
+++ b/docs/api/features/placement.md
@@ -10,7 +10,6 @@ services and avoiding single points of failure (SPOF).
 This document explains how Triton places new containers on servers and what
 facilities are exposed for controlling placement.
 
-
 ## Default placement
 
 By default, Triton makes a reasonable attempt to spread all containers (and
@@ -19,7 +18,7 @@ physical servers.
 
 Within a Docker container the physical server on which a container is running
 is exposed via the [`sdc:server_uuid` metadata
-key](http://eng.joyent.com/mdata/datadict.html):
+key](http://eng.tritondatacenter.com/mdata/datadict.html):
 
     $ docker run -ti --rm alpine /bin/sh
     / # hostname
@@ -38,7 +37,7 @@ By running another container we can see this default spread behavior (the
 
 Outside the containers, the physical server on which a container is running
 is exposed via the `compute_node` field using the [Triton
-CLI](https://github.com/joyent/node-triton):
+CLI](https://github.com/TritonDataCenter/sdc/node-triton):
 
     $ triton insts -o shortid,name,age,compute_node
     SHORTID   NAME             AGE  COMPUTE_NODE
@@ -46,9 +45,8 @@ CLI](https://github.com/joyent/node-triton):
     98d5a22a  goofy_engelbart  2m   44454c4c-4400-1054-8052-b5c04f383432
 
 Note that [there are many factors in placement
-decisions](https://github.com/joyent/sdc-designation/blob/master/docs/index.md),
+decisions](https://github.com/TritonDataCenter/sdc/sdc-designation/blob/master/docs/index.md),
 including DC operator-controlled spread policies, so results may vary.
-
 
 ## Swarm affinity
 
@@ -66,11 +64,11 @@ where node selection is described in terms of existing containers. For example:
     #                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # Run a mysql instance that is NOT on the same node as container 'db0'.
 
-For the same reasons, node selection can matter on Triton. Triton's Docker 
-implements the same affinity filters as documented for Docker Swarm, with the 
-difference that you don't need to setup a Swarm cluster. Affinity Filters are 
+For the same reasons, node selection can matter on Triton. Triton's Docker
+implements the same affinity filters as documented for Docker Swarm, with the
+difference that you don't need to setup a Swarm cluster. Affinity Filters are
 also called "locality hints" in Triton (see the [cloudapi CreateMachine notes](
-https://apidocs.joyent.com/cloudapi/#CreateMachine)).
+https://apidocs.tritondatacenter.com/cloudapi/#CreateMachine)).
 
 ### Affinity filter syntax
 
@@ -84,7 +82,6 @@ Swarm [code](https://github.com/docker/swarm/blob/d9beef7/cluster/config.go#L83-
 but not [documented](https://docs.docker.com/swarm/scheduler/filter/).)
 
     docker run --label 'com.docker.swarm.affinities=["<filter>",...]' ...
-
 
 A `<filter>` is one of the following. (Note: Swarm defines "image filters"
 which don't apply for Triton because any image in the datacenter is available
@@ -133,7 +130,6 @@ Note: At the time of writing the label syntax is in Docker Swarm
 [code](https://github.com/docker/swarm/blob/d9beef7/cluster/config.go#L83-L86),
 but not [documented](https://docs.docker.com/swarm/scheduler/filter/).
 
-
 ### Affinity in the Triton CLI
 
 For users of both Docker and non-Docker containers (and VMs) on Triton, the
@@ -145,7 +141,6 @@ syntax:
 
     # Run on a different node to 'db0':
     triton create -a 'container!=db0' ...
-
 
 ## Placement failure
 

--- a/docs/api/features/resources.md
+++ b/docs/api/features/resources.md
@@ -3,14 +3,14 @@
 When you create a container with sdc-docker, your container will have an
 associated "package". The package will be used to determine such things as:
 
- * CPU shares
- * DRAM (memory)
- * Disk quota
- * I/O priority
+* CPU shares
+* DRAM (memory)
+* Disk quota
+* I/O priority
 
 appropriate for the system your container is provisioned to. The package
 parameters can be found using the `triton package list` command using
-the [node-triton tool](https://github.com/joyent/node-triton).
+the [node-triton tool](https://github.com/TritonDataCenter/sdc/node-triton).
 
 When creating a container with `docker create` or `docker run` you can specify
 the package using the special label `com.joyent.package`. This label can be used
@@ -18,9 +18,7 @@ with `docker create` or `docker run` to choose a specific package. The value
 should be either a package name like `g4-standard-1G`, a UUID or the first 8
 characters of a UUID (short-UUID).  For example:
 
-```
-docker run -it --label com.joyent.package=g4-standard-1G alpine /bin/sh
-```
+    docker run -it --label com.joyent.package=g4-standard-1G alpine /bin/sh
 
 will create a container using the g4-standard-1G package. If you specify the
 com.joyent.package label, any -m argument will be ignored.
@@ -34,9 +32,7 @@ the nearest package.
 Regardless of how your docker container was provisioned, you can use the package
 as a filter for `docker ps`. To filter you can use the format:
 
-```
-docker ps --filter "label=com.joyent.package=g4-standard-1G"
-```
+    docker ps --filter "label=com.joyent.package=g4-standard-1G"
 
 which would show you only those docker containers that are using the
 `g4-standard-1G` package.
@@ -51,14 +47,14 @@ the first 8 characters of the package UUID. The order of precedence is:
 
  2. package name
 
-     If the argument is /^[0-9a-f]{8}$/ and matches both a uuid and a name,
+     If the argument is `/^[0-9a-f]{8}$/` and matches both a uuid and a name,
      the package with the name that matches is used. If the argument does not
      match the short-UUID pattern, and is not a UUID, it's only looked up
      against package names.
 
  3. short-UUID
 
-     If the argument is /^[0-9a-f]{8}$/ and does not match a name, it will
+     If the argument is `/^[0-9a-f]{8}$/` and does not match a name, it will
      be looked up against the first 8 characters of the available package UUIDs.
 
 if none of these match you will get an error.
@@ -66,11 +62,9 @@ if none of these match you will get an error.
 In order to see the packages for your existing containers you can also do
 something like:
 
-```
-docker ps -a --format '{{.ID}} {{.Label "com.joyent.package"}}'
-```
+    docker ps -a --format '{{.ID}} {{.Label "com.joyent.package"}}'
 
 which will output the id and package name for each container. If there are
 problems looking up the name of the package because you no longer have access to
-the package or the package is no longer active, you may see '<unknown>' as the
+the package or the package is no longer active, you may see `<unknown>` as the
 package name.

--- a/docs/api/features/volumes.md
+++ b/docs/api/features/volumes.md
@@ -3,34 +3,32 @@
 With sdc-docker, there are some limitations on volumes that are slightly
 different from Docker Inc's docker:
 
- * there is a limit of 8 'data' volumes per container
- * 'host' volumes (/hostpath:/containerpath) are not supported
- * you cannot delete a container which has a volume that another container is
-   sharing (via --volumes-from), you must first delete all containers using that
-   volume.
- * there is a limit of 1 --volumes-from argument per container
- * When you use --volumes-from you are necessarily coprovisioned with the
-   container you are sharing the volumes from. If the physical host on which
-   the source container exists does not have capacity for the new container,
-   provisioning a new container using --volumes-from will fail.
- * When you use --volumes-from, volumes that don't belong to the container
-   specified (including those that this container is sharing from others) are
-   ignored. Only volumes belonging to the specified container will be
-   considered.
+* there is a limit of 8 'data' volumes per container
+* 'host' volumes (/hostpath:/containerpath) are not supported
+* you cannot delete a container which has a volume that another container is
+  sharing (via --volumes-from), you must first delete all containers using that
+  volume.
+* there is a limit of 1 --volumes-from argument per container
+* When you use --volumes-from you are necessarily coprovisioned with the
+  container you are sharing the volumes from. If the physical host on which
+  the source container exists does not have capacity for the new container,
+  provisioning a new container using --volumes-from will fail.
+* When you use --volumes-from, volumes that don't belong to the container
+  specified (including those that this container is sharing from others) are
+  ignored. Only volumes belonging to the specified container will be
+  considered.
 
 ## Experimental support for NFS shared volumes
 
 The NFS shared volumes feature is described in detail by its corresponding [RFD
-document](https://github.com/joyent/rfd/blob/master/rfd/0026/README.md).
+document](https://github.com/TritonDataCenter/sdc/rfd/blob/master/rfd/0026/README.md).
 
 To enable support for NFS shared volumes in Triton, run the following command
 line from the head node:
 
-```
-sdcadm post-setup volapi
-sdcadm experimental nfs-volumes docker
-sdcadm experimental nfs-volumes docker-automount
-```
+    sdcadm post-setup volapi
+    sdcadm experimental nfs-volumes docker
+    sdcadm experimental nfs-volumes docker-automount
 
 This command will create a new core zone that runs the VOLAPI service, which
 implements the Volumes API. It will also enable the
@@ -47,9 +45,7 @@ The `experimental_docker_nfs_shared_volumes` SAPI flag can be set to `false` in
 SAPI to disable support for NFS shared volumes by running the following command
 line:
 
-```
-sdcadm experimental nfs-volumes docker -d
-```
+    sdcadm experimental nfs-volumes docker -d
 
 After disabling this setting, running `docker volume` commands will result in an
 error message.

--- a/docs/api/troubleshooting.md
+++ b/docs/api/troubleshooting.md
@@ -40,7 +40,6 @@ You get a "TLS-enabled daemon without TLS" error:
     $ docker info
     FATA[0000] Get http:///var/run/docker.sock/v1.17/info: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS
 
-
 One possibility is that after running sdc-docker-setup.sh, did you run
 the `export` and `alias` commands in your shell.
 

--- a/docs/development/docker-issues.md
+++ b/docs/development/docker-issues.md
@@ -1,39 +1,36 @@
 # Docker Issue Links
 
-Notes and links to docker issues and PRs on which Joyent engineers are involved
+Notes and links to docker issues and PRs on which Triton engineers are involved
 or which are particular relevant or interesting.
-
 
 ## Networking
 
 libnetwork IRC discussions:
-https://github.com/docker/docker/issues/8951#issuecomment-61872174
+<https://github.com/docker/docker/issues/8951#issuecomment-61872174>
 
-Networking survey: https://docs.google.com/a/docker.com/forms/d/1EK6j5pEE14dHrxB2DAkwjiMg0KzDpMN__o-QkIX9OcQ/viewform?c=0&w=1
-https://docs.google.com/spreadsheets/d/1fNrTR25N6t9TEdEs5fHWGc3XQeydNCIvtwWBGMNwvvw/edit?pli=1#gid=1588369297
+Networking survey:
 
+* <https://docs.google.com/a/docker.com/forms/d/1EK6j5pEE14dHrxB2DAkwjiMg0KzDpMN__o-QkIX9OcQ/viewform?c=0&w=1>
+* <https://docs.google.com/spreadsheets/d/1fNrTR25N6t9TEdEs5fHWGc3XQeydNCIvtwWBGMNwvvw/edit?pli=1#gid=1588369297>
 
 ## Related to `docker top`
 
- * [Question about /container/id/top command #7205](https://github.com/docker/docker/issues/7205) (which lead to:)
- * [Proposal: Make API for `/containers/(id)/top` independent of implementation #9232](https://github.com/docker/docker/pull/9232)
+* [Question about /container/id/top command #7205](https://github.com/docker/docker/issues/7205) (which lead to:)
+* [Proposal: Make API for `/containers/(id)/top` independent of implementation #9232](https://github.com/docker/docker/pull/9232)
 
 ## ZFS
 
- * [Implement Docker on ZFS](https://github.com/docker/docker/pull/7901). Has first functional version in branch.
-
+* [Implement Docker on ZFS](https://github.com/docker/docker/pull/7901). Has first functional version in branch.
 
 ## Related to `docker stats`
 
- * [Problems with implementation / doc mismatch on /stats](https://github.com/docker/docker/issues/10711).
-
+* [Problems with implementation / doc mismatch on /stats](https://github.com/docker/docker/issues/10711).
 
 ## Problem with --restart
 
- * [Issue with --restart=no not being passed by client](https://github.com/docker/docker/issues/10874).
- * [The fix for #10874 made things worse](https://github.com/docker/docker/issues/12413).
-
+* [Issue with --restart=no not being passed by client](https://github.com/docker/docker/issues/10874).
+* [The fix for #10874 made things worse](https://github.com/docker/docker/issues/12413).
 
 ## docker-machine
 
- * [Add option to skip SSH provisioning](https://github.com/docker/machine/issues/886)
+* [Add option to skip SSH provisioning](https://github.com/docker/machine/issues/886)

--- a/docs/development/images.md
+++ b/docs/development/images.md
@@ -11,7 +11,7 @@ markdown2linkpatternsfile: link-patterns.txt
 
 <!--
     Copyright (c) 2014, Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # SDC Docker Images plan
@@ -54,7 +54,6 @@ by sdc-docker. If we intend to change this design point, then beware that
 sdc-docker will be removing unused/abandoned docker images in the background
 (e.g. when last user does a 'docker rmi ID' for a given image ID).
 
-
 # Docker images on vanilla SmartOS
 
 First let's briefly discuss how Docker image handling on vanilla SmartOS could
@@ -89,7 +88,6 @@ imgadm somehow. Ancestry is handled via the `origin` image manifest field.
 
 The rest of this document is about supporting Docker images on *SDC*.
 
-
 # Docker images on SDC
 
 "Docker in SDC" at the time of writing means a SDC core "docker" service
@@ -103,12 +101,15 @@ a single Docker host for each user. That has some implications:
 
 There are three main relevant systems for handling docker images in SDC:
 
-1. the [docker SAPI service](https://github.com/joyent/sdc-docker), aka sdc-docker
-2. [IMGAPI](https://github.com/joyent/sdc-imgapi), and
-3. [`imgadm`](https://github.com/joyent/smartos-live/tree/master/src/img) on each node.
+1. the [docker SAPI service](https://github.com/TritonDataCenter/sdc/sdc-docker), aka sdc-docker
+2. [IMGAPI](https://github.com/TritonDataCenter/sdc/sdc-imgapi), and
+3. [`imgadm`](https://github.com/TritonDataCenter/sdc/smartos-live/tree/master/src/img) on each node.
+
+<!-- markdownlint-disable link-fragments -->
 
 See the [tl;dr](#tl-dr) section above for the basic plan.
 
+<!-- markdownlint-enable link-fragments -->
 
 # Use Cases
 
@@ -135,7 +136,7 @@ a whole.)
 - sdc-docker: hits Docker index and registry as appropriate to gather the
   *repository tags* and layer info
 - sdc-docker: calls IMGAPI
-  [AdminImportRemoteImage](https://mo.joyent.com/docs/imgapi/master/#AdminImportRemoteImage),
+  [AdminImportRemoteImage](https://github.com/TritonDataCenter/sdc-imgapi/blob/master/docs/index.md#adminimportremoteimage-post-imagesuuidactionimport-remote),
   or perhaps new AdminImportRemoteDockerImage endpoint
 - imgapi: creates a WF job to handle the import
 - sdc-docker: on import success, commit docker image tags and set of pulled
@@ -184,7 +185,6 @@ C. When the ref count on a docker image goes to zero, set a "can delete
 
 I like (C).
 
-
 ## Use Case 4: `docker images`
 
 - user: `docker images ...`
@@ -196,7 +196,6 @@ I like (C).
 Dev Note: Likely want a bulk endpoint on IMGAPI to be able to get information
 for a number of images in one request -- instead of hitting IMGAPI 100 times to
 list 100 docker images. Get IMGAPI caching correct to make that fast.
-
 
 ## Use Case 5: `docker history`
 
@@ -218,7 +217,6 @@ ListImageAncestry which takes an image UUID.
         ...
     ]
 
-
 ## Use Case 6: `docker pull https://my-private-repo.example.com/bob/mongo`
 
 TODO
@@ -227,22 +225,19 @@ TODO
 
 TODO
 
-
 # Milestones
 
 TODO: Integrate these with the full sdc-docker project plan. A potential
 ordering:
 
 - `docker pull|images|history|inspect`
-    - really need the IMGAPI local cache (see img-mgmt plan)
+  - really need the IMGAPI local cache (see img-mgmt plan)
 - `docker rmi`
-    -
 - `docker pull` support for repositories other than the default
 - speed: start tracking time to do all these endpoints
 - plan out `docker commit|build|push` et al
 - plan out billing story
 - plan out support for easy private docker image repos
-
 
 # Design Notes
 
@@ -260,13 +255,13 @@ of pulled docker images per user. These will be in moray. Buckets:
 2. `docker_image_ids`: Per-user set of pulled docker image ids.
    Columns:  `key` (unused), `owner_uuid`, `image_id`.
 
-
 ## Why store docker native format in IMGAPI?
 
 One question is whether to have IMGAPI store native docker layer file data,
 or have it store the data transformed into zone datasets.
 
 Native docker format:
+
 - Pro: We always have the original data in-case we need to fix a problem with
   "aufs to zfs-dataset" translation.
 - Pro: IMGAPI implementations are easier: don't require ability to use `zfs`.
@@ -278,6 +273,7 @@ Native docker format:
   should help with possible future support for "Docker on vanilla SmartOS".
 
 Zone datasets:
+
 - Pro: Would only need to do the "aufs to zfs-dataset" translation once,
   instead of independently on each node.
 - Con: Handling conversion failures would be a pain at this level. Basically
@@ -286,8 +282,6 @@ Zone datasets:
 - Pro: Updating the *docker service* for processing bugs is easier than
   having to update `imgadm` in a platform for processing bugs (modulo
   having some mini-platform upgrade story).
-
-
 
 # Open Questions
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -15,7 +15,7 @@ exposed as a single Docker host. The SDC Docker engine runs as the 'docker' SMF
 service in a 'docker' core SDC zone.
 
 This document includes details on operating an SDC Docker image. If you are interested in developing
-the Docker Engine for SDC, see the [sdc-docker README](https://github.com/joyent/sdc-docker/blob/master/README.md).
+the Docker Engine for SDC, see the [sdc-docker README](https://github.com/TritonDataCenter/sdc-docker/blob/master/README.md).
 
 The Docker Engine for SmartDataCenter treats the entire data center as
 a single Docker host. Each container is a SmartOS LX-branded zone. Benefits:
@@ -29,22 +29,17 @@ a single Docker host. Each container is a SmartOS LX-branded zone. Benefits:
   support (VXLAN) means you have a private network between all your containers,
   across servers.
 
-And the full stack is open source: [sdc-docker](https://github.com/joyent/sdc-docker),
-[SmartDataCenter](https://github.com/joyent/sdc),
-and [SmartOS](https://github.com/joyent/smartos-live).
-
-**A note for users of Joyent's public cloud:** Joyent is hosting a beta of
-their Docker service. Please sign up at https://www.joyent.com/lp/preview and
-read on for the settings for the standard Docker client.
-
+And the full stack is open source: [sdc-docker](https://github.com/TritonDataCenter/sdc-docker),
+[Triton Data Center](https://github.com/TritonDataCenter/triton),
+and [SmartOS](https://github.com/TritonDataCenter/smartos-live).
 
 ## Current Status
 
 The Docker Engine for SDC is currently in alpha and under heavy development.
 The current focus is on stabilization and filling out support for *building* and
 *running* Docker containers.
-Please [report issues](https://github.com/joyent/sdc-docker/issues),
-give us feedback or discuss on [#joyent IRC on libera.chat](irc://libera.chat/#joyent).
+Please [report issues](https://github.com/TritonDataCenter/sdc-docker/issues),
+give us feedback or discuss on [#triton IRC on libera.chat](irc://libera.chat/#triton).
 
 ### 3. sdc-docker-setup.sh
 
@@ -56,32 +51,29 @@ client certificate to identify requests as coming from you.
 
 Follow the steps in [the API guide to get connected and start using SDC Docker](../api/README.md).
 
-
 ## Package Selection
 
-If the docker client specifies either -m (memory) or -c (cpu\_shares), we'll look
-through the list of packages with `packagePrefix*` as their name, and find the
-smallest package which has values larger than both provided. If no value is
-provided for `cpu_shares`, this parameter is ignored. If no value is provided for
-memory, the defaultMemory value is used as though the user had passed that.
-
+If the docker client specifies either -m (memory) or -c (`cpu_shares`), we'll
+look through the list of packages with `packagePrefix*` as their name, and find
+the smallest package which has values larger than both provided. If no value is
+provided for `cpu_shares`, this parameter is ignored. If no value is provided
+for memory, the defaultMemory value is used as though the user had passed that.
 
 ## Service Configuration
 
 The SDC Docker service can be configured with the following Service API
 (SAPI) metadata values.
 
-| Key                            | Type    | Default | Description                                                                  |
-| ------------------------------ | ------- | ------- | ----------- |
-| **USE_TLS**                    | Boolean | false   | Turn on TLS authentication. |
-| **DEFAULT_MEMORY**       | Number | 1024 | The default ram/memory to use for docker containers. |
-| **PACKAGE_PREFIX** | String | 'sample-'    | The prefix for packages to use for docker container package selection. |
+| Key              | Type    | Default   | Description                                                            |
+| ---------------- | ------- | --------- | ---------------------------------------------------------------------- |
+| `USE_TLS`        | Boolean | false     | Turn on TLS authentication.                                            |
+| `DEFAULT_MEMORY` | Number  | 1024      | The default ram/memory to use for docker containers.                   |
+| `PACKAGE_PREFIX` | String  | `sample-` | The prefix for packages to use for docker container package selection. |
 
 ### Example
 
     docker_svc=$(sdc-sapi /services?name=docker | json -Ha uuid)
     sdc-sapi /services/$docker_svc -X PUT -d '{ "metadata": { "USE_TLS": true } }'
-
 
 ## Configuration
 
@@ -92,23 +84,23 @@ typically written out by config-agent using the
 
 | var | type | default | description |
 | --- | ---- | ------- | ----------- |
-| datacenterName | String | coal | Data center name to use as the Docker engine name. |
-| defaultMemory | Number | 1024 | The amount of memory to choose if no -m is provided. |
-| packagePrefix | String | sample- | PAPI will be consulted with a request `PREFIX*` when looking for packages |
-| externalNetwork | String | external | The network name (in NAPI) from which select an IP for docker container provisioning *in non-overlay networks mode*. |
-| port | Number | 2375 | Port number on which the Docker engine listens. |
-| logLevel | String/Number | debug | Level at which to log. One of the supported Bunyan log levels. |
-| maxSockets | Number | 100 | Maximum number of sockets for external API calls |
-| backend | String | sdc | One of 'sdc' (all of SDC is a docker host) or 'lxzone' (just the CN is the docker host, this requires running the docker service in the GZ, not currently supported). |
-| moray.host | String | - | The Moray server hostname for this DC. |
-| moray.port | Number | 2020 | Port number on which the Moray server listens. |
-| moray.logLevel | String/Number | info | Level at which the Moray client should log. One of the supported Bunyan log levels. |
-| cnapi.url | String | - | The CNAPI URL for this DC. |
-| imgapi.url | String | - | The IMGAPI URL for this DC. |
-| napi.url | String | - | The NAPI URL for this DC. |
-| papi.url | String | - | The PAPI URL for this DC. |
-| vmapi.url | String | - | The VMAPI URL for this DC. |
-| wfapi.url | String | - | The WFAPI URL for this DC. |
+| datacenterName  | String        | coal     | Data center name to use as the Docker engine name. |
+| defaultMemory   | Number        | 1024     | The amount of memory to choose if no -m is provided. |
+| packagePrefix   | String        | sample-  | PAPI will be consulted with a request `PREFIX*` when looking for packages |
+| externalNetwork | String        | external | The network name (in NAPI) from which select an IP for docker container provisioning *in non-overlay networks mode*. |
+| port            | Number        | 2375     | Port number on which the Docker engine listens. |
+| logLevel        | String/Number | debug    | Level at which to log. One of the supported Bunyan log levels. |
+| maxSockets      | Number        | 100      | Maximum number of sockets for external API calls |
+| backend         | String        | sdc      | One of 'sdc' (all of SDC is a docker host) or 'lxzone' (just the CN is the docker host, this requires running the docker service in the GZ, not currently supported). |
+| moray.host      | String        | -        | The Moray server hostname for this DC. |
+| moray.port      | Number        | 2020     | Port number on which the Moray server listens. |
+| moray.logLevel  | String/Number | info     | Level at which the Moray client should log. One of the supported Bunyan log levels. |
+| cnapi.url       | String        | -        | The CNAPI URL for this DC. |
+| imgapi.url      | String        | -        | The IMGAPI URL for this DC. |
+| napi.url        | String        | -        | The NAPI URL for this DC. |
+| papi.url        | String        | -        | The PAPI URL for this DC. |
+| vmapi.url       | String        | -        | The VMAPI URL for this DC. |
+| wfapi.url       | String        | -        | The WFAPI URL for this DC. |
 
 ## Client usage
 
@@ -118,24 +110,20 @@ your environment variables for the `docker` client.
 
 ### 2. Set Up an SDC Account
 
-See the [User Management](https://docs.joyent.com/sdc7/user-management) operator guide documentation on how to create a user in SmartDataCenter.
+See the [User Management](https://docs.tritondatacenter.com/private-cloud/users) operator guide documentation on how to create a user in SmartDataCenter.
 
-The [SmartDataCenter CLI environment](https://apidocs.joyent.com/cloudapi/#getting-started) is not necessary for to use Docker on SDC,
+The [Triton CLI environment](https://apidocs.tritondatacenter.com/cloudapi/#getting-started) is not necessary for to use Docker on Triton,
 but for beta testing it will be helpful. To test that your
-SmartDataCenter client environment is configured, you can run `sdc-getaccount`:
+Triton client environment is configured, you can run `triton profile get`:
 
-    $ sdc-getaccount
-    {
-      "id": "....387c",
-      "login": "jill",
-      "email": "jill@example.com",
-      "companyName": "Acme",
-      "firstName": "Jill",
-      ...
-    }
+    $ triton profile get
+    name: env
+    account: jill
+    curr: true
+    keyId: SHA256:...
+    url: https://cloudapi....
 
-If `sdc-getaccount` works, then complete the [steps to configure the Docker client in the API guide](../api/).
-
+If `triton profile get` works, then complete the [steps to configure the Docker client in the API guide](../api/).
 
 ## TODO
 

--- a/docs/link-patterns.txt
+++ b/docs/link-patterns.txt
@@ -1,1 +1,1 @@
-/([A-Z]+-\d+)/ https://devhub.joyent.com/jira/browse/\1
+/([A-Z]+-\d+)/ https://smartos.org/bugview/\1

--- a/lib/backends/sdc/utils.js
+++ b/lib/backends/sdc/utils.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2017, Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 var assert = require('assert-plus');
@@ -74,7 +75,7 @@ function shortNetworkIdToUuidPrefix(id) {
 
 /**
  * Docker containers are stored on the VM "tags" field
- * (https://github.com/joyent/sdc-vmapi/blob/master/docs/index.md#vm-metadata).
+ * (https://github.com/TritonDataCenter/sdc/sdc-vmapi/blob/master/docs/index.md#vm-metadata).
  * General docker labels are prefixed with 'docker:label:' (AFAIK the only
  * need for that separation is the use of the 'sdc_docker' tag for fwrules).
  *

--- a/lib/backends/sdc/utils.js
+++ b/lib/backends/sdc/utils.js
@@ -75,7 +75,7 @@ function shortNetworkIdToUuidPrefix(id) {
 
 /**
  * Docker containers are stored on the VM "tags" field
- * (https://github.com/TritonDataCenter/sdc/sdc-vmapi/blob/master/docs/index.md#vm-metadata).
+ * (TritonDataCenter/sdc-vmapi/blob/master/docs/index.md#vm-metadata).
  * General docker labels are prefixed with 'docker:label:' (AFAIK the only
  * need for that separation is the use of the 'sdc_docker' tag for fwrules).
  *

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -395,7 +395,7 @@ NetworkNotFoundError.description = 'Network not found';
  * An error used to expose the error from a node-sdc-clients API request.
  *
  * This *prefers* they are following:
- *      https://github.com/TritonDataCenter/sdc/eng/blob/master/docs/index.md#error-handling
+ *      TritonDataCenter/triton/eng/blob/master/docs/index.md#error-handling
  * but we have enough exceptions, even in APIs like IMGAPI that try hard
  * to be defensive.
  */

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -394,7 +395,7 @@ NetworkNotFoundError.description = 'Network not found';
  * An error used to expose the error from a node-sdc-clients API request.
  *
  * This *prefers* they are following:
- *      https://github.com/joyent/eng/blob/master/docs/index.md#error-handling
+ *      https://github.com/TritonDataCenter/sdc/eng/blob/master/docs/index.md#error-handling
  * but we have enough exceptions, even in APIs like IMGAPI that try hard
  * to be defensive.
  */

--- a/lib/models/image-tag-v2.js
+++ b/lib/models/image-tag-v2.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -37,7 +38,7 @@ var BUCKET = {
             /*
              * The "localName" for the Docker repo. See
              * // JSSTYLED
-             * <https://github.com/joyent/node-docker-registry-client/tree/master#overview>
+             * <https://github.com/TritonDataCenter/sdc/node-docker-registry-client/tree/master#overview>
              */
             repo: { type: 'string' },
             tag: { type: 'string' }

--- a/lib/models/image-tag.js
+++ b/lib/models/image-tag.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -38,7 +39,7 @@ var BUCKET = {
             /*
              * The "localName" for the Docker repo. See
              * // JSSTYLED
-             * <https://github.com/joyent/node-docker-registry-client/tree/master#names>
+             * <https://github.com/TritonDataCenter/sdc/node-docker-registry-client/tree/master#names>
              */
             repo: { type: 'string' },
             tag: { type: 'string' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdc-docker",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {

--- a/test/runtest.common
+++ b/test/runtest.common
@@ -7,6 +7,7 @@
 
 #
 # Copyright 2018, Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -77,7 +78,7 @@ fi
 #
 # The only available compose version for now is 1.9.0 because it is what
 # triton-docker uses (see
-# https://github.com/joyent/triton-docker-cli/blob/4cc524dcb1a9d12adf192e057ca737fcf80069be/triton-docker#L5)
+# https://github.com/TritonDataCenter/sdc/triton-docker-cli/blob/4cc524dcb1a9d12adf192e057ca737fcf80069be/triton-docker#L5)
 # and triton-docker represents the closest thing to what's officially supported
 # by sdc-docker as possible.
 export COMPOSE_AVAILABLE_CLI_VERSIONS="1.9.0"

--- a/tools/check-docs.sh
+++ b/tools/check-docs.sh
@@ -7,6 +7,7 @@
 
 #
 # Copyright (c) 2017, Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -18,7 +19,7 @@
 # Checks:
 #
 # 1. Ensure files end with a newline, else the import into
-#    apidocs.joyent.com.git gets grumpy.
+#    apidocs.tritondatacenter.com.git gets grumpy.
 #
 #
 
@@ -42,7 +43,7 @@ while read -d $'\0' -r file; do
     # Map the newline character into a space, and spaces into
     # an underscore, since bash likes to trim trailing newlines
     # from command outputs.
-    if [[ `tail -1c "$file" | tr ' \n' '_ '` != ' ' ]]; then
+    if [[ $(tail -1c "$file" | tr ' \n' '_ ') != ' ' ]]; then
         echo "$file: does not end with a newline" >&2
         hits=1
     fi

--- a/tools/get-docker-clients.sh
+++ b/tools/get-docker-clients.sh
@@ -7,6 +7,7 @@
 
 #
 # Copyright 2016, Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -42,7 +43,7 @@ set -o nounset
 # ---- globals
 
 # Note: Should keep this in sync with "DOCKER_AVAILABLE_CLI_VERIONS"
-# https://github.com/joyent/sdc-docker/blob/master/test/runtest.common#L54
+# https://github.com/TritonDataCenter/sdc/sdc-docker/blob/master/test/runtest.common#L54
 DEFAULT_VERS="1.12.2 1.11.1 1.10.3 1.9.1 1.8.3"
 
 WRKDIR=/var/tmp/tmp.get-docker-clients


### PR DESCRIPTION
This doesn't change the software behavior at all. All changes are to documentation or comments.

In addition to changing references to apidocs.joyent.com, other Joyent references have been changed to MNX, altered, or removed as necessary. This also fixes a lot of markdown lint issues (and creates the accompanying `.markdownlint.json` file to ignore a few things that are pervasive). I only updated markdown for the files I touched, but there are still a ton more markdown lint warnings that should be corrected eventually.

Sorry it's so big. There's not really a reasonable way to do this in smaller chunks and be atomic.